### PR TITLE
Change output to match the Linux version of free

### DIFF
--- a/free.c
+++ b/free.c
@@ -34,7 +34,7 @@ void formatBytes(unsigned long long bytes, char *buffer, int bufferSize, int hum
         suffixIndex++;
     }
 
-    snprintf(buffer, bufferSize, "%.2f %s", result, suffixes[suffixIndex]);
+    snprintf(buffer, bufferSize, "%.1f%s", result, suffixes[suffixIndex]);
 }
 
 // void dumpVmStat(vm_statistics64_data_t *vm, long pagesize, long TotalRAM) {
@@ -177,12 +177,12 @@ int main(int argc, char **argv) {
         formatBytes(swapinfo.xsu_avail, swap.free, sizeof(swap.free), human);
 
         /* print the header */
-        printf("%20s %14s %14s %14s %14s %14s\n",
+        printf("%20s %11s %11s %11s %11s %11s\n",
             "total", "used", "free", "cached", "app", "wired");
         /* display the memory usage statistics */
-         printf("Mem: %15s %14s %14s %14s %14s %14s\n",
+         printf("Mem: %15s %11s %11s %11s %11s %11s\n",
              mem.total, mem.used, mem.free, mem.cached, mem.app, mem.wired);
-         printf("Swap: %14s %14s %14s\n", swap.total, swap.used, swap.free);
+         printf("Swap: %14s %11s %11s\n", swap.total, swap.used, swap.free);
 
         /* does the loop continue? */
         if (poll != 0) {

--- a/free.c
+++ b/free.c
@@ -24,7 +24,7 @@ void formatBytes(unsigned long long bytes, char *buffer, int bufferSize, int hum
         return;
     }
     
-    const char *suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+    const char *suffixes[] = {"B", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"};
     int suffixIndex = 0;
     double result = 0.0;
 


### PR DESCRIPTION
The units and white space are slightly different, but I wanted `free` and `lima free` to match...

So I changed the output to look like the Linux version, i.e. specifically the one from Ubuntu.

```console
$ free -h
               total        used        free      cached         app       wired
Mem:          16.0Gi       8.8Gi       1.3Gi       5.8Gi       6.8Gi       1.1Gi
Swap:           0.0B        0.0B        0.0B
$ uname
Darwin
$ lima free -h
               total        used        free      shared  buff/cache   available
Mem:           3.8Gi       363Mi       2.9Gi       5.2Mi       679Mi       3.5Gi
Swap:             0B          0B          0B
$ lima uname
Linux
```

Hmm, perhaps the "0B" needs to be tweaked as well.

Then again, also missing `-g` and `-m` and `-k` et al...